### PR TITLE
codebase support

### DIFF
--- a/src/deploy/functions/prepareFunctionsUpload.ts
+++ b/src/deploy/functions/prepareFunctionsUpload.ts
@@ -138,7 +138,9 @@ export async function prepareFunctionsUpload(
 ): Promise<PackagedSourceInfo | undefined> {
   if (config.isolate === true) {
     utils.logLabeledBullet("functions", `Start isolating the source folder...`);
+    const cwd = process.cwd();
     try {
+      process.chdir(sourceDir);
       /**
        * Use a dynamic import because isolate-package depends on ESM.
        * A normal "await import()" gets transpiled to require() so we use the
@@ -157,6 +159,8 @@ export async function prepareFunctionsUpload(
     } catch (err: any) {
       utils.logLabeledBullet("functions", `+++ Failed to isolate: ${err.message}`);
       throw err;
+    } finally {
+      process.chdir(cwd);
     }
   } else {
     return packageSource(sourceDir, config, runtimeConfig);


### PR DESCRIPTION
Hi. So I've been happily using `firebase-tools-with-isolate` for a little while, on a monorepo with a single monolithic firebase backend package. I've reached the point where I'd like to split that up into separate chunks using firebase `codebase`s. For example:

```
/packages
  /firebase-backend
    /codebases
      /chunk1
      /chunk2
    /firebase.json
    /src
      /some-other-firebase-functions-and-definitions-here
```

with `firebase.json` containing:

```json
{
  "functions": [{
    "source": ".",
    "runtime": "nodejs20",
    "isolate": true,
    "codebase": "default"
  },
  {
    "source": "codebases/chunk1",
    "runtime": "nodejs20",
    "isolate": true,
    "codebase": "chunk1"
  },
  {
    "source": "codebases/chunk2",
    "runtime": "nodejs20",
    "isolate": true,
    "codebase": "chunk2"
  }]
}
```

I was unable to get Firebase to attempt to deploy the codebases unless they were part of the `/packages/firebase-backend` tree, and when it did deploy it kept uploading the `default` codebase bundle instead of the bundle for each codebase.

I did some digging and ended up patching `firebase-tools-with-isolate` and `isolate-package` so that it does now correctly deploy each codebase bundle. There's two PRs for discussion, one here and one for `isolate-package`, and I fully expect that these don't work for other usecases so take them simply as a point of discussion to see if there's a way forward that _would_ work for all scenarios. 

The changes in this PR are just to correctly set `cwd` when running `isolate()` so that the `process.cwd()` calls in `isolate-package` operate within the codebase directory, instead of the firebase root. That allowed me then to write an `isolate.config.json` file within each codebase, to correctly point far enough up the tree to reach the workspace root.

```json
{
  "workspaceRoot": "../../../.."
}
```

The `isolate-package` changes are basically about preventing it from caching any config, so each call to `isolate()` starts from scratch and doesn't get confused with previously created state.