### PR TITLE
Rename default branch from master to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   publish:
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     # Authentication is handled via OIDC trusted publishing (id-token),
     # so no NPM_TOKEN secret is needed.

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -109,7 +109,7 @@ jobs:
           BRANCH=$(git branch --show-current)
 
           # Close any existing PR for this sync
-          EXISTING=$(gh pr list --base master --head "$BRANCH" --json number --jq '.[0].number // empty' 2>/dev/null || true)
+          EXISTING=$(gh pr list --base main --head "$BRANCH" --json number --jq '.[0].number // empty' 2>/dev/null || true)
           if [[ -n "$EXISTING" ]]; then
             echo "Closing existing PR #$EXISTING"
             gh pr close "$EXISTING" 2>/dev/null || true
@@ -140,9 +140,9 @@ jobs:
             -f title="Sync with upstream $TARGET_TAG" \
             -f body="$BODY" \
             -f head="$BRANCH" \
-            -f base="master" \
+            -f base="main" \
             --jq '.html_url'; then
             echo ""
             echo "::warning::Failed to create PR. The branch was pushed successfully."
-            echo "Create the PR manually: https://github.com/${{ github.repository }}/compare/master...$BRANCH"
+            echo "Create the PR manually: https://github.com/${{ github.repository }}/compare/main...$BRANCH"
           fi

--- a/.github/workflows/update-isolate.yml
+++ b/.github/workflows/update-isolate.yml
@@ -1,7 +1,7 @@
 name: Update isolate-package
 
 # Updates the isolate-package dependency to a new version, bumps the fork's
-# pre-release number, and opens a PR to master.
+# pre-release number, and opens a PR to main.
 #
 # Use this when you've published a pre-release of isolate-package and want to
 # test it within the firebase-tools-with-isolate fork.
@@ -24,7 +24,7 @@ on:
 
 jobs:
   update:
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -132,7 +132,7 @@ jobs:
           BRANCH=$(git branch --show-current)
 
           # Close any existing PR for this branch
-          EXISTING=$(gh pr list --base master --head "$BRANCH" --json number --jq '.[0].number // empty' 2>/dev/null || true)
+          EXISTING=$(gh pr list --base main --head "$BRANCH" --json number --jq '.[0].number // empty' 2>/dev/null || true)
           if [[ -n "$EXISTING" ]]; then
             echo "Closing existing PR #$EXISTING"
             gh pr close "$EXISTING" 2>/dev/null || true
@@ -157,9 +157,9 @@ jobs:
             -f title="Update isolate-package to ${ISOLATE_VERSION}" \
             -f body="$BODY" \
             -f head="$BRANCH" \
-            -f base="master" \
+            -f base="main" \
             --jq '.html_url'; then
             echo ""
             echo "::warning::Failed to create PR. The branch was pushed successfully."
-            echo "Create the PR manually: https://github.com/${{ github.repository }}/compare/master...$BRANCH"
+            echo "Create the PR manually: https://github.com/${{ github.repository }}/compare/main...$BRANCH"
           fi

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ All workflows use Node 24 and npm OIDC trusted publishing (provenance).
 
 - **[`sync-upstream.yml`](.github/workflows/sync-upstream.yml)** — Runs daily (09:00 UTC) and on manual dispatch. Checks for new upstream firebase-tools releases and opens a PR with the synced result. Can target a specific version.
 
-- **[`update-isolate.yml`](.github/workflows/update-isolate.yml)** — Updates the `isolate-package` dependency to a given version, bumps the fork's pre-release number (e.g. `15.13.0-0` → `15.13.0-1`), and commits to master. Follow up with the publish workflow to release to npm.
+- **[`update-isolate.yml`](.github/workflows/update-isolate.yml)** — Updates the `isolate-package` dependency to a given version, bumps the fork's pre-release number (e.g. `15.13.0-0` → `15.13.0-1`), and commits to main. Follow up with the publish workflow to release to npm.
 
 - **[`publish.yml`](.github/workflows/publish.yml)** — Publishes the fork to npm. Choose `next` for pre-release testing or `latest` to promote a stable release (which strips the pre-release suffix, e.g. `15.13.0-0` → `15.13.0`). Creates a git tag and GitHub release.
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ All workflows use Node 24 and npm OIDC trusted publishing (provenance).
 
 - **[`sync-upstream.yml`](.github/workflows/sync-upstream.yml)** — Runs daily (09:00 UTC) and on manual dispatch. Checks for new upstream firebase-tools releases and opens a PR with the synced result. Can target a specific version.
 
-- **[`update-isolate.yml`](.github/workflows/update-isolate.yml)** — Updates the `isolate-package` dependency to a given version, bumps the fork's pre-release number (e.g. `15.13.0-0` → `15.13.0-1`), and commits to main. Follow up with the publish workflow to release to npm.
+- **[`update-isolate.yml`](.github/workflows/update-isolate.yml)** — Updates the `isolate-package` dependency to a given version, bumps the fork's pre-release number (e.g. `15.13.0-0` → `15.13.0-1`), and opens a PR targeting `main`. Follow up with the publish workflow to release to npm. Follow up with the publish workflow to release to npm.
 
 - **[`publish.yml`](.github/workflows/publish.yml)** — Publishes the fork to npm. Choose `next` for pre-release testing or `latest` to promote a stable release (which strips the pre-release suffix, e.g. `15.13.0-0` → `15.13.0`). Creates a git tag and GitHub release.
 

--- a/scripts/sync/fork-readme.md
+++ b/scripts/sync/fork-readme.md
@@ -97,7 +97,7 @@ All workflows use Node 24 and npm OIDC trusted publishing (provenance).
 
 - **[`sync-upstream.yml`](.github/workflows/sync-upstream.yml)** — Runs daily (09:00 UTC) and on manual dispatch. Checks for new upstream firebase-tools releases and opens a PR with the synced result. Can target a specific version.
 
-- **[`update-isolate.yml`](.github/workflows/update-isolate.yml)** — Updates the `isolate-package` dependency to a given version, bumps the fork's pre-release number (e.g. `15.13.0-0` → `15.13.0-1`), and commits to master. Follow up with the publish workflow to release to npm.
+- **[`update-isolate.yml`](.github/workflows/update-isolate.yml)** — Updates the `isolate-package` dependency to a given version, bumps the fork's pre-release number (e.g. `15.13.0-0` → `15.13.0-1`), and commits to main. Follow up with the publish workflow to release to npm.
 
 - **[`publish.yml`](.github/workflows/publish.yml)** — Publishes the fork to npm. Choose `next` for pre-release testing or `latest` to promote a stable release (which strips the pre-release suffix, e.g. `15.13.0-0` → `15.13.0`). Creates a git tag and GitHub release.
 

--- a/scripts/sync/fork-readme.md
+++ b/scripts/sync/fork-readme.md
@@ -97,7 +97,7 @@ All workflows use Node 24 and npm OIDC trusted publishing (provenance).
 
 - **[`sync-upstream.yml`](.github/workflows/sync-upstream.yml)** — Runs daily (09:00 UTC) and on manual dispatch. Checks for new upstream firebase-tools releases and opens a PR with the synced result. Can target a specific version.
 
-- **[`update-isolate.yml`](.github/workflows/update-isolate.yml)** — Updates the `isolate-package` dependency to a given version, bumps the fork's pre-release number (e.g. `15.13.0-0` → `15.13.0-1`), and commits to main. Follow up with the publish workflow to release to npm.
+- **[`update-isolate.yml`](.github/workflows/update-isolate.yml)** — Updates the `isolate-package` dependency to a given version, bumps the fork's pre-release number (e.g. `15.13.0-0` → `15.13.0-1`), and opens a PR targeting `main`. Follow up with the publish workflow to release to npm. Follow up with the publish workflow to release to npm.
 
 - **[`publish.yml`](.github/workflows/publish.yml)** — Publishes the fork to npm. Choose `next` for pre-release testing or `latest` to promote a stable release (which strips the pre-release suffix, e.g. `15.13.0-0` → `15.13.0`). Creates a git tag and GitHub release.
 

--- a/scripts/sync/sync-upstream.sh
+++ b/scripts/sync/sync-upstream.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 #
 # What it does:
 #   1. Fetches the latest upstream tags
-#   2. Creates a sync branch from master
+#   2. Creates a sync branch from main
 #   3. Merges the upstream release tag (preferring upstream for conflicts)
 #   4. Re-applies isolate-package integration changes cleanly
 #   5. Runs npm install + build to verify correctness
@@ -129,10 +129,10 @@ fi
 echo ""
 echo "🌿 Creating branch: $BRANCH_NAME"
 
-# Make sure we're on master and up to date
-git checkout master --quiet
+# Make sure we're on main and up to date
+git checkout main --quiet
 if git remote get-url origin &>/dev/null; then
-  git pull origin master --quiet
+  git pull origin main --quiet
 fi
 
 # Delete existing branch if it exists. Use safe delete (-d) first; only
@@ -341,7 +341,7 @@ if [[ "$PUSH" == true ]]; then
 
   echo ""
   echo "✅ Done! Create a PR:"
-  echo "   https://github.com/0x80/firebase-tools-with-isolate/compare/master...$BRANCH_NAME"
+  echo "   https://github.com/0x80/firebase-tools-with-isolate/compare/main...$BRANCH_NAME"
 else
   echo ""
   echo "✅ Done! (--no-push: branch not pushed)"


### PR DESCRIPTION
Updates all workflow files, the sync script, and documentation to reference `main` instead of `master` as the default branch, aligning with upstream firebase-tools.

The git branch itself has already been renamed and the GitHub default branch setting updated. This PR contains the file reference updates.

Scope: infra
Visibility: internal