### PR TITLE
Automate sync + publish pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,9 +3,10 @@ name: Publish
 # Publishes the fork to npm using OIDC trusted publishing (provenance).
 # Requires Node.js 24+ and npm OIDC trust configured for this repository.
 #
-# Run this workflow manually after merging a sync PR.
-# Choose "next" to publish the pre-release version (e.g. 15.13.0-0),
-# or "latest" to strip the pre-release suffix and publish stable (e.g. 15.13.0).
+# Called automatically by the sync-upstream workflow after a successful sync,
+# or can be triggered manually. Choose "next" to publish the pre-release
+# version (e.g. 15.13.0-0), or "latest" to strip the pre-release suffix
+# and publish stable (e.g. 15.13.0).
 
 on:
   workflow_dispatch:
@@ -18,6 +19,18 @@ on:
         options:
           - next
           - latest
+      dry_run:
+        description: "Dry run — skip publish, push, and release"
+        required: false
+        type: boolean
+        default: false
+  workflow_call:
+    inputs:
+      dist_tag:
+        description: "npm dist-tag"
+        required: false
+        type: string
+        default: "next"
       dry_run:
         description: "Dry run — skip publish, push, and release"
         required: false
@@ -40,6 +53,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -27,8 +27,13 @@ permissions:
   contents: write
   id-token: write
 
+concurrency:
+  group: sync-upstream
+  cancel-in-progress: false
+
 jobs:
   sync:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     outputs:
       synced: ${{ steps.result.outputs.synced }}

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,10 +1,12 @@
 name: Sync Upstream
 
-# Checks for new upstream firebase-tools releases and creates a sync PR.
+# Syncs with new upstream firebase-tools releases and publishes to npm.
 #
 # Runs daily, or can be triggered manually with an optional target version
 # and isolate-package version override. The already-synced check exits
 # immediately when there is no new release, so daily polling is cheap.
+# When a new version is found, it merges upstream, pushes to main, and
+# triggers the publish workflow.
 
 on:
   schedule:
@@ -23,11 +25,13 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
+  id-token: write
 
 jobs:
   sync:
     runs-on: ubuntu-latest
+    outputs:
+      synced: ${{ steps.result.outputs.synced }}
 
     steps:
       - name: Checkout fork
@@ -93,56 +97,28 @@ jobs:
 
           bash scripts/sync/sync-upstream.sh "${ARGS[@]}"
 
-      - name: Push sync branch
+      - name: Merge to main
         if: steps.check.outputs.skip != 'true'
         run: |
           BRANCH=$(git branch --show-current)
-          git push -u origin "$BRANCH" --force-with-lease
+          git checkout main
+          git merge "$BRANCH" --ff-only
 
-      - name: Create Pull Request
+      - name: Push to main
         if: steps.check.outputs.skip != 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TARGET_TAG: ${{ steps.version.outputs.tag }}
-          VERSION_NUMBER: ${{ steps.check.outputs.version_number }}
-        run: |
-          BRANCH=$(git branch --show-current)
+        run: git push origin main
 
-          # Close any existing PR for this sync
-          EXISTING=$(gh pr list --base main --head "$BRANCH" --json number --jq '.[0].number // empty' 2>/dev/null || true)
-          if [[ -n "$EXISTING" ]]; then
-            echo "Closing existing PR #$EXISTING"
-            gh pr close "$EXISTING" 2>/dev/null || true
-          fi
+      - name: Set sync result
+        id: result
+        if: steps.check.outputs.skip != 'true'
+        run: echo "synced=true" >> "$GITHUB_OUTPUT"
 
-          BODY=$(cat <<EOF
-          Automated sync with upstream [firebase-tools ${TARGET_TAG}](https://github.com/firebase/firebase-tools/releases/tag/${TARGET_TAG}).
-
-          **Fork version:** \`${VERSION_NUMBER}-0\`
-
-          ### What this PR does
-          - Merges all changes from firebase-tools \`${TARGET_TAG}\`
-          - Re-applies the isolate-package integration on top
-
-          ### Review checklist
-          - [ ] Build passes
-          - [ ] Isolate integration changes look correct
-          - [ ] No unintended file changes
-
-          ---
-          _Created by the [sync-upstream](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) workflow._
-          EOF
-          )
-
-          # Use the REST API directly — gh pr create uses GraphQL which can
-          # fail with "Resource not accessible by integration" on forks.
-          if ! gh api repos/${{ github.repository }}/pulls \
-            -f title="Sync with upstream $TARGET_TAG" \
-            -f body="$BODY" \
-            -f head="$BRANCH" \
-            -f base="main" \
-            --jq '.html_url'; then
-            echo ""
-            echo "::warning::Failed to create PR. The branch was pushed successfully."
-            echo "Create the PR manually: https://github.com/${{ github.repository }}/compare/main...$BRANCH"
-          fi
+  publish:
+    needs: sync
+    if: needs.sync.outputs.synced == 'true'
+    uses: ./.github/workflows/publish.yml
+    with:
+      dist_tag: latest
+    permissions:
+      contents: write
+      id-token: write

--- a/scripts/sync/fork-readme.md
+++ b/scripts/sync/fork-readme.md
@@ -95,7 +95,7 @@ The sync can also be triggered manually:
 
 All workflows use Node 24 and npm OIDC trusted publishing (provenance).
 
-- **[`sync-upstream.yml`](.github/workflows/sync-upstream.yml)** — Runs daily (09:00 UTC) and on manual dispatch. Checks for new upstream firebase-tools releases and opens a PR with the synced result. Can target a specific version.
+- **[`sync-upstream.yml`](.github/workflows/sync-upstream.yml)** — Runs daily (09:00 UTC) and on manual dispatch. Checks for new upstream firebase-tools releases, merges to main, and triggers the publish workflow automatically. Can target a specific version.
 
 - **[`update-isolate.yml`](.github/workflows/update-isolate.yml)** — Updates the `isolate-package` dependency to a given version, bumps the fork's pre-release number (e.g. `15.13.0-0` → `15.13.0-1`), and opens a PR targeting `main`. Follow up with the publish workflow to release to npm. Follow up with the publish workflow to release to npm.
 
@@ -106,6 +106,10 @@ All workflows use Node 24 and npm OIDC trusted publishing (provenance).
 - Sync creates version `X.Y.Z-0` matching upstream `vX.Y.Z`
 - Each isolate-package update bumps the suffix: `-0` → `-1` → `-2`
 - Publishing to `latest` strips the suffix: `X.Y.Z-0` → `X.Y.Z`
+
+## Issues
+
+Issues on this repository are disabled. If you encounter a problem related to the isolate process or monorepo deployment, please submit it at [isolate-package](https://github.com/0x80/isolate-package/issues). For issues unrelated to the isolate integration, refer to the upstream [firebase-tools](https://github.com/firebase/firebase-tools/issues).
 
 ## Documentation
 


### PR DESCRIPTION
The sync workflow previously created a PR requiring manual merge, followed by a manual publish trigger. Since branch protection no longer requires PRs, this replaces that flow with direct push to main and automatic publish.

The sync workflow now merges the sync branch to main, pushes, and triggers the publish workflow via `workflow_call` with `dist_tag=latest`. When the daily cron finds no new upstream version, it exits early as a no-op.

The publish workflow gains a `workflow_call` trigger so it can be called from sync, while remaining manually triggerable via `workflow_dispatch`.

Scope: infra
Visibility: internal