### PR TITLE
Prevent sync workflow from overwriting isolate-package version

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -45,7 +45,7 @@
         "glob": "^10.5.0",
         "google-auth-library": "^9.11.0",
         "ignore": "^7.0.4",
-        "isolate-package": "^1.27.0-4",
+        "isolate-package": "^1.30.0",
         "js-yaml": "^3.14.2",
         "jsonwebtoken": "^9.0.2",
         "leven": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "glob": "^10.5.0",
     "google-auth-library": "^9.11.0",
     "ignore": "^7.0.4",
-    "isolate-package": "^1.27.0-4",
+    "isolate-package": "^1.30.0",
     "js-yaml": "^3.14.2",
     "jsonwebtoken": "^9.0.2",
     "leven": "^3.1.0",

--- a/scripts/sync/apply-isolate-changes.mjs
+++ b/scripts/sync/apply-isolate-changes.mjs
@@ -99,6 +99,7 @@ function patchPackageJson() {
     );
     process.exit(1);
   }
+  pkg.dependencies ??= {};
   pkg.dependencies["isolate-package"] = isolateVersion;
 
   // Remove publishConfig — upstream uses Google's internal Wombat Dressing Room

--- a/scripts/sync/apply-isolate-changes.mjs
+++ b/scripts/sync/apply-isolate-changes.mjs
@@ -12,7 +12,7 @@
  *
  * Options:
  *   --version, -v           Upstream version (read from package.json if omitted)
- *   --isolate-version, -i   isolate-package semver range (default: ^1.27.0-4)
+ *   --isolate-version, -i   isolate-package semver range (default: current value in package.json)
  */
 
 import { readFileSync, writeFileSync, copyFileSync } from "node:fs";
@@ -26,11 +26,7 @@ const ROOT = join(__dirname, "..", "..");
 const { values: args } = parseArgs({
   options: {
     version: { type: "string", short: "v" },
-    "isolate-version": {
-      type: "string",
-      short: "i",
-      default: "^1.27.0-4",
-    },
+    "isolate-version": { type: "string", short: "i" },
   },
 });
 
@@ -90,8 +86,20 @@ function patchPackageJson() {
     }
   }
 
-  // Add isolate-package dependency (sorted position doesn't matter, npm handles it)
-  pkg.dependencies["isolate-package"] = args["isolate-version"];
+  // Fall back to the value already in package.json when --isolate-version
+  // wasn't passed. This only helps direct manual invocations: the sync
+  // pipeline calls this script *after* merging upstream, at which point
+  // package.json no longer has an isolate-package key. sync-upstream.sh
+  // captures the value before the merge and always passes it explicitly.
+  const isolateVersion =
+    args["isolate-version"] ?? pkg.dependencies?.["isolate-package"];
+  if (!isolateVersion) {
+    console.error(
+      "\n❌ --isolate-version not provided and package.json has no dependencies['isolate-package']\n",
+    );
+    process.exit(1);
+  }
+  pkg.dependencies["isolate-package"] = isolateVersion;
 
   // Remove publishConfig — upstream uses Google's internal Wombat Dressing Room
   // registry which we can't and shouldn't use

--- a/scripts/sync/sync-upstream.sh
+++ b/scripts/sync/sync-upstream.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 # Options:
 #   --target, -t VERSION    Upstream version to sync to (e.g. v15.13.0).
 #                           Defaults to the latest upstream release tag.
-#   --isolate-version, -i   isolate-package version (default: ^1.27.0-4)
+#   --isolate-version, -i   isolate-package version (default: current value in package.json)
 #   --branch, -b NAME       Branch name to create. Defaults to auto-generated.
 #   --no-push               Don't push the branch (for local testing).
 #   --no-build              Skip the build verification step.
@@ -30,7 +30,7 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 # Defaults
 TARGET_VERSION=""
-ISOLATE_VERSION="^1.27.0-4"
+ISOLATE_VERSION=""
 BRANCH_NAME=""
 PUSH=true
 BUILD=true
@@ -51,7 +51,7 @@ Usage:
 Options:
   --target, -t VERSION    Upstream version to sync to (e.g. v15.13.0).
                           Defaults to the latest upstream release tag.
-  --isolate-version, -i   isolate-package version (default: ^1.27.0-4)
+  --isolate-version, -i   isolate-package version (default: current value in package.json)
   --branch, -b NAME       Branch name to create. Defaults to auto-generated.
   --no-push               Don't push the branch (for local testing).
   --no-build              Skip the build verification step.
@@ -64,6 +64,21 @@ HELP
 done
 
 cd "$ROOT_DIR"
+
+# If no --isolate-version was provided, preserve the current value from
+# package.json. This MUST happen before the upstream merge: the merge uses
+# -X theirs and replaces package.json with upstream's copy, which has no
+# isolate-package key at all — so reading it later would come up empty.
+# The `|| ''` in the node expression is load-bearing: without it, a missing
+# key would print the literal text "undefined" and silently pass the check.
+if [[ -z "$ISOLATE_VERSION" ]]; then
+  ISOLATE_VERSION=$(node -p "require('./package.json').dependencies['isolate-package'] || ''")
+  if [[ -z "$ISOLATE_VERSION" ]]; then
+    echo "❌ --isolate-version not provided and package.json has no dependencies['isolate-package']"
+    exit 1
+  fi
+  echo "   Using isolate-package version from package.json: $ISOLATE_VERSION"
+fi
 
 # ---------------------------------------------------------------------------
 # Step 1: Fetch upstream

--- a/scripts/sync/sync-upstream.sh
+++ b/scripts/sync/sync-upstream.sh
@@ -72,7 +72,7 @@ cd "$ROOT_DIR"
 # The `|| ''` in the node expression is load-bearing: without it, a missing
 # key would print the literal text "undefined" and silently pass the check.
 if [[ -z "$ISOLATE_VERSION" ]]; then
-  ISOLATE_VERSION=$(node -p "require('./package.json').dependencies['isolate-package'] || ''")
+  ISOLATE_VERSION=$(node -p "require('./package.json').dependencies?.['isolate-package'] || ''")
   if [[ -z "$ISOLATE_VERSION" ]]; then
     echo "❌ --isolate-version not provided and package.json has no dependencies['isolate-package']"
     exit 1


### PR DESCRIPTION
The daily `sync-upstream` workflow was silently resetting `dependencies.isolate-package` in `package.json` back to a hardcoded default (`^1.27.0-4`) on every run, wiping out any version bump that had just been landed by the `update-isolate` workflow.

## Problem

`scripts/sync/sync-upstream.sh` had a hardcoded `ISOLATE_VERSION="^1.27.0-4"` default, which it passed to `scripts/sync/apply-isolate-changes.mjs`. That script unconditionally overwrites `pkg.dependencies["isolate-package"]` with whatever value it receives. The daily cron trigger in `sync-upstream.yml` fires without an `isolate_package_version` input, so the hardcoded default always won.

The fallback cannot live inside `apply-isolate-changes.mjs`: by the time that script runs, the upstream merge (`git merge -X theirs`) has already replaced `package.json` with upstream firebase-tools' copy, which has no `isolate-package` key at all. The current value must be captured *before* the merge.

## Fix

`scripts/sync/sync-upstream.sh` now reads the current `dependencies.isolate-package` from `package.json` before the merge runs, and uses that as the default when `--isolate-version` is not passed explicitly. The `workflow_dispatch` override still wins when provided. A missing key yields a clear error instead of silently writing `"undefined"` into `package.json` (the `|| ''` in the `node -p` expression is load-bearing — without it, a missing property stringifies to the literal text `undefined`).

`scripts/sync/apply-isolate-changes.mjs` gets a matching defensive fallback for direct manual invocations on a clean main checkout: if `--isolate-version` isn't passed, it reads from the existing `package.json`, erroring out if the key is missing.

Also restores `dependencies.isolate-package` to `^1.30.0` in `package.json`, since the current value on main is the stale one left behind by the last broken sync run.

Scope: infra
Visibility: internal