### PR TITLE
Push and publish directly from update-isolate workflow

### DIFF
--- a/.github/workflows/update-isolate.yml
+++ b/.github/workflows/update-isolate.yml
@@ -21,7 +21,6 @@ on:
 
 permissions:
   contents: write
-  id-token: write
 
 concurrency:
   group: update-isolate

--- a/.github/workflows/update-isolate.yml
+++ b/.github/workflows/update-isolate.yml
@@ -1,13 +1,10 @@
 name: Update isolate-package
 
 # Updates the isolate-package dependency to a new version, bumps the fork's
-# pre-release number, and opens a PR to main.
+# pre-release number, pushes to main, and publishes to npm as the 'next' tag.
 #
 # Use this when you've published a pre-release of isolate-package and want to
 # test it within the firebase-tools-with-isolate fork.
-#
-# After the PR is merged, trigger the "Publish" workflow to publish
-# the updated version to npm.
 
 on:
   workflow_dispatch:
@@ -17,21 +14,31 @@ on:
         required: true
         type: string
       dry_run:
-        description: "Dry run — skip push"
+        description: "Dry run — skip push and publish"
         required: false
         type: boolean
         default: false
+
+permissions:
+  contents: write
+  id-token: write
+
+concurrency:
+  group: update-isolate
+  cancel-in-progress: false
 
 jobs:
   update:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
+    outputs:
+      ready: ${{ steps.result.outputs.ready }}
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -70,13 +77,6 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Create branch
-        env:
-          ISOLATE_VERSION: ${{ steps.isolate.outputs.version }}
-        run: |
-          BRANCH="update-isolate/${ISOLATE_VERSION}"
-          git checkout -b "$BRANCH"
-
       - name: Bump pre-release version
         id: version
         env:
@@ -114,52 +114,22 @@ jobs:
           echo "- **Fork version:** ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Tag:** ${{ steps.version.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Dry run:** ${{ inputs.dry_run }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Run the **Publish** workflow with dist-tag \`next\` to publish this version." >> $GITHUB_STEP_SUMMARY
 
-      - name: Push branch
+      - name: Push to main
         if: ${{ inputs.dry_run == false }}
-        run: |
-          BRANCH=$(git branch --show-current)
-          git push -u origin "$BRANCH" --force-with-lease
+        run: git push origin main
 
-      - name: Create Pull Request
+      - name: Set ready flag
+        id: result
         if: ${{ inputs.dry_run == false }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISOLATE_VERSION: ${{ steps.isolate.outputs.version }}
-        run: |
-          BRANCH=$(git branch --show-current)
+        run: echo "ready=true" >> "$GITHUB_OUTPUT"
 
-          # Close any existing PR for this branch
-          EXISTING=$(gh pr list --base main --head "$BRANCH" --json number --jq '.[0].number // empty' 2>/dev/null || true)
-          if [[ -n "$EXISTING" ]]; then
-            echo "Closing existing PR #$EXISTING"
-            gh pr close "$EXISTING" 2>/dev/null || true
-          fi
-
-          BODY=$(cat <<EOF
-          Update [isolate-package](https://www.npmjs.com/package/isolate-package) to \`${ISOLATE_VERSION}\`.
-
-          **Fork version:** \`${{ steps.version.outputs.version }}\`
-          **Tag:** \`${{ steps.version.outputs.tag }}\`
-
-          Run the **Publish** workflow with dist-tag \`next\` to publish this version after merging.
-
-          ---
-          _Created by the [update-isolate](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) workflow._
-          EOF
-          )
-
-          # Use the REST API directly — gh pr create uses GraphQL which can
-          # fail with "Resource not accessible by integration" on forks.
-          if ! gh api repos/${{ github.repository }}/pulls \
-            -f title="Update isolate-package to ${ISOLATE_VERSION}" \
-            -f body="$BODY" \
-            -f head="$BRANCH" \
-            -f base="main" \
-            --jq '.html_url'; then
-            echo ""
-            echo "::warning::Failed to create PR. The branch was pushed successfully."
-            echo "Create the PR manually: https://github.com/${{ github.repository }}/compare/main...$BRANCH"
-          fi
+  publish:
+    needs: update
+    if: needs.update.outputs.ready == 'true'
+    uses: ./.github/workflows/publish.yml
+    with:
+      dist_tag: next
+    permissions:
+      contents: write
+      id-token: write


### PR DESCRIPTION
The update-isolate workflow previously created a dedicated `update-isolate/<version>` branch, pushed it, opened a PR to main, and expected the operator to merge the PR and then manually trigger the Publish workflow. sync-upstream.yml already handles its equivalent flow without any of that: it commits on main, pushes, and chains publish.yml via `workflow_call`. This aligns update-isolate with the same pattern.

The dependency bump and `npm version prerelease` commits now land directly on main. After the push, a second job calls `./.github/workflows/publish.yml` with `dist_tag: next`, gated on a `ready` output that is only set when `dry_run` is false — dry runs skip both the push and the chained publish job (otherwise publish would check out stale main). The workflow-level `permissions` now includes `id-token: write` so the called publish job inherits the OIDC trust needed for provenance publishing, and a `concurrency: update-isolate` group matches sync-upstream's guardrails.

Scope: ci (update-isolate workflow)
Visibility: internal