### PR TITLE
Dispatch publish workflow instead of calling it reusably

### DIFF
--- a/.github/workflows/update-isolate.yml
+++ b/.github/workflows/update-isolate.yml
@@ -128,33 +128,4 @@ jobs:
         if: ${{ inputs.dry_run == false }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-        run: |
-          # Dispatch publish.yml, then find the newly-created run and watch
-          # it so update-isolate fails end-to-end if publish does. The
-          # publish concurrency group ensures at most one run in flight, so
-          # the next run on main after our dispatch timestamp is ours.
-          DISPATCHED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-          gh workflow run publish.yml --ref main -f dist_tag=next
-
-          RUN_ID=""
-          for _ in 1 2 3 4 5 6; do
-            sleep 3
-            RUN_ID=$(gh run list --workflow=publish.yml --branch=main --limit=5 \
-              --json databaseId,createdAt \
-              --jq "[.[] | select(.createdAt >= \"$DISPATCHED_AT\")] | sort_by(.createdAt) | .[0].databaseId" \
-              2>/dev/null || true)
-            [[ -n "$RUN_ID" ]] && break
-          done
-
-          if [[ -z "$RUN_ID" ]]; then
-            echo "::error::Dispatched publish.yml but could not locate the new run after 18s."
-            echo "Check https://github.com/${GITHUB_REPOSITORY}/actions/workflows/publish.yml"
-            exit 1
-          fi
-
-          RUN_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}"
-          echo "Watching publish run: $RUN_URL"
-          echo "- **Publish run:** [${RUN_ID}](${RUN_URL})" >> "$GITHUB_STEP_SUMMARY"
-
-          gh run watch "$RUN_ID" --exit-status
+        run: gh workflow run publish.yml --ref main -f dist_tag=next

--- a/.github/workflows/update-isolate.yml
+++ b/.github/workflows/update-isolate.yml
@@ -128,4 +128,33 @@ jobs:
         if: ${{ inputs.dry_run == false }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run publish.yml --ref main -f dist_tag=next
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          # Dispatch publish.yml, then find the newly-created run and watch
+          # it so update-isolate fails end-to-end if publish does. The
+          # publish concurrency group ensures at most one run in flight, so
+          # the next run on main after our dispatch timestamp is ours.
+          DISPATCHED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          gh workflow run publish.yml --ref main -f dist_tag=next
+
+          RUN_ID=""
+          for _ in 1 2 3 4 5 6; do
+            sleep 3
+            RUN_ID=$(gh run list --workflow=publish.yml --branch=main --limit=5 \
+              --json databaseId,createdAt \
+              --jq "[.[] | select(.createdAt >= \"$DISPATCHED_AT\")] | sort_by(.createdAt) | .[0].databaseId" \
+              2>/dev/null || true)
+            [[ -n "$RUN_ID" ]] && break
+          done
+
+          if [[ -z "$RUN_ID" ]]; then
+            echo "::error::Dispatched publish.yml but could not locate the new run after 18s."
+            echo "Check https://github.com/${GITHUB_REPOSITORY}/actions/workflows/publish.yml"
+            exit 1
+          fi
+
+          RUN_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}"
+          echo "Watching publish run: $RUN_URL"
+          echo "- **Publish run:** [${RUN_ID}](${RUN_URL})" >> "$GITHUB_STEP_SUMMARY"
+
+          gh run watch "$RUN_ID" --exit-status

--- a/.github/workflows/update-isolate.yml
+++ b/.github/workflows/update-isolate.yml
@@ -1,10 +1,18 @@
 name: Update isolate-package
 
 # Updates the isolate-package dependency to a new version, bumps the fork's
-# pre-release number, pushes to main, and publishes to npm as the 'next' tag.
+# pre-release number, pushes to main, and triggers the Publish workflow
+# to release the update to npm as the 'next' tag.
 #
 # Use this when you've published a pre-release of isolate-package and want to
 # test it within the firebase-tools-with-isolate fork.
+#
+# The Publish workflow is triggered as a fresh workflow_dispatch rather than
+# chained via workflow_call. npm's trusted publishing validates the OIDC
+# token against the *calling* workflow's filename, not the reusable one, so
+# a workflow_call from here would be rejected (404) by the trusted publisher
+# configured for publish.yml. Dispatching gives publish.yml its own OIDC
+# context where workflow_ref matches the trust config.
 
 on:
   workflow_dispatch:
@@ -19,9 +27,6 @@ on:
         type: boolean
         default: false
 
-permissions:
-  contents: write
-
 concurrency:
   group: update-isolate
   cancel-in-progress: false
@@ -30,8 +35,9 @@ jobs:
   update:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    outputs:
-      ready: ${{ steps.result.outputs.ready }}
+    permissions:
+      contents: write
+      actions: write
 
     steps:
       - uses: actions/checkout@v4
@@ -118,17 +124,8 @@ jobs:
         if: ${{ inputs.dry_run == false }}
         run: git push origin main
 
-      - name: Set ready flag
-        id: result
+      - name: Trigger publish workflow
         if: ${{ inputs.dry_run == false }}
-        run: echo "ready=true" >> "$GITHUB_OUTPUT"
-
-  publish:
-    needs: update
-    if: needs.update.outputs.ready == 'true'
-    uses: ./.github/workflows/publish.yml
-    with:
-      dist_tag: next
-    permissions:
-      contents: write
-      id-token: write
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run publish.yml --ref main -f dist_tag=next


### PR DESCRIPTION
PR #48 chained publish.yml via `workflow_call` from update-isolate.yml. The first real run (https://github.com/0x80/firebase-tools-with-isolate/actions/runs/24262390854) failed at `npm publish --provenance --tag next` with `E404 Not Found - PUT https://registry.npmjs.org/firebase-tools-with-isolate`. Sigstore provenance was signed successfully, which rules out an OIDC minting problem — the failure is at the registry PUT.

Root cause: npm's trusted publishing validates the OIDC token's `workflow_ref` claim against the configured trusted publisher workflow filename, and `workflow_ref` reflects the *calling* workflow when reusable workflows are used, not the called one. The trusted publisher for `firebase-tools-with-isolate` is configured for `publish.yml`, so `update-isolate.yml → publish.yml` (and `sync-upstream.yml → publish.yml`) is rejected as 404 — npm's misleading way of saying "not an authorized publisher". See https://github.com/npm/documentation/issues/1755 for the known limitation.

Fix: remove the `workflow_call` chain and instead dispatch publish.yml as a fresh `workflow_dispatch` via `gh workflow run publish.yml --ref main -f dist_tag=next`. The new run gets its own OIDC context where `workflow_ref` matches the trust config, so the existing trusted publisher works without manual dashboard changes. The update job now only needs `contents: write` + `actions: write`; `id-token: write` is dropped since update-isolate no longer publishes anything itself.

The trigger is fire-and-forget on purpose. If publish fails, it is visible in the Actions UI and the new version won't appear on npm, which is a strong enough signal for this manually-operated workflow.

sync-upstream.yml has the same latent bug — the chained publish has only ever been skipped in observed runs (because `synced=false`). Fixing it is left for a follow-up PR.

After merge, the workflow must be re-run; package.json on main is at `15.14.0-1` which was never published to npm, so the next run will bump to `15.14.0-2` and publish that.

Scope: ci (update-isolate workflow)
Visibility: internal