### PR TITLE
Skip dependency commit when isolate-package version is unchanged

### DIFF
--- a/.github/workflows/update-isolate.yml
+++ b/.github/workflows/update-isolate.yml
@@ -88,9 +88,14 @@ jobs:
           ISOLATE_VERSION: ${{ steps.isolate.outputs.version }}
         run: |
           # Stage changes from npm pkg set + npm install so npm version
-          # doesn't fail on a dirty working directory
+          # doesn't fail on a dirty working directory. If the dependency
+          # was already at the requested version (e.g. when re-running to
+          # recover from a failed publish), skip this commit — we still
+          # want the pre-release bump below.
           git add package.json npm-shrinkwrap.json
-          git commit -m "Update isolate-package to ${ISOLATE_VERSION}"
+          if ! git diff --cached --quiet; then
+            git commit -m "Update isolate-package to ${ISOLATE_VERSION}"
+          fi
 
           # If the version has no prerelease suffix (e.g. after publishing to
           # "latest" which strips it), restore the "-0" suffix first. Without


### PR DESCRIPTION
Run https://github.com/0x80/firebase-tools-with-isolate/actions/runs/24275621103 failed at "Bump pre-release version" with:

```
On branch main
Your branch is up to date with 'origin/main'.

nothing to commit, working tree clean
##[error]Process completed with exit code 1.
```

The workflow was triggered with `isolate_version = 1.31.0`, which is already what package.json on main points at. `npm pkg set` + `npm install` produced no diff, so `git commit -m "Update isolate-package to 1.31.0"` exited 1 and bash `-e` killed the step before the pre-release bump could run.

This case arises naturally when re-running update-isolate to recover from a failed publish (package.json on main is currently at `15.14.0-1`, which never actually hit the npm registry because the earlier `workflow_call → publish.yml` run 404'd at PUT). The user's intent in that scenario is "bump the fork pre-release and re-publish" even though the dependency itself hasn't moved.

Fix: make the dependency commit conditional on there being staged changes. If there's nothing to commit, skip it and proceed to `npm version prerelease`, which still runs and produces the pre-release bump commit.

Scope: ci (update-isolate workflow)
Visibility: internal