### PR TITLE
Raise monorepo detection depth via FIREBASE_TOOLS_ISOLATE_MONOREPO_MAX_DEPTH

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ In package.json scripts, `npx` is not required — scripts already prefer locall
 
 No configuration is required. When you run `firebase deploy`, the fork calls `detectMonorepo` from `detect-monorepo` on the functions source directory. If a workspace root is found (pnpm-workspace.yaml, a parent `package.json` with a `workspaces` field, or `rush.json`), isolation runs automatically. Otherwise the deploy proceeds exactly as in upstream firebase-tools.
 
+`detect-monorepo` walks up from the functions source with a default depth cap. If your functions source is nested deeper than that default and the workspace root isn't being found, set `FIREBASE_TOOLS_ISOLATE_MONOREPO_MAX_DEPTH` to a positive integer (or `Infinity`) to raise the cap:
+
+```bash
+FIREBASE_TOOLS_ISOLATE_MONOREPO_MAX_DEPTH=20 npx firebase deploy
+```
+
 ```json
 {
   "functions": {

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "cross-spawn": "^7.0.5",
     "csv-parse": "^5.0.4",
     "deep-equal-in-any-order": "^2.0.6",
-    "detect-monorepo": "^1.1.0",
+    "detect-monorepo": "^1.2.0",
     "exegesis": "^4.2.0",
     "exegesis-express": "^4.0.0",
     "express": "^4.16.4",

--- a/scripts/sync/apply-isolate-changes.mjs
+++ b/scripts/sync/apply-isolate-changes.mjs
@@ -159,9 +159,16 @@ function patchPrepareFunctionsUpload() {
  * Check whether the given absolute source directory sits inside a monorepo
  * workspace (pnpm, npm/yarn/bun workspaces, or Rush). Used as a cheap gate
  * before invoking isolate-package.
+ *
+ * Uses detect-monorepo's default upward walk depth. Set
+ * FIREBASE_TOOLS_ISOLATE_MONOREPO_MAX_DEPTH to a positive integer (or
+ * Infinity) to raise the cap when the functions source is nested deeper than
+ * the default.
  */
 export function isMonorepoSource(absoluteSourceDir: string): boolean {
-  return detectMonorepo(absoluteSourceDir) !== null;
+  const override = process.env.FIREBASE_TOOLS_ISOLATE_MONOREPO_MAX_DEPTH;
+  const options = override ? { maxDepth: Number(override) } : undefined;
+  return detectMonorepo(absoluteSourceDir, options) !== null;
 }
 
 /**

--- a/scripts/sync/fork-readme.md
+++ b/scripts/sync/fork-readme.md
@@ -30,6 +30,12 @@ In package.json scripts, `npx` is not required — scripts already prefer locall
 
 No configuration is required. When you run `firebase deploy`, the fork calls `detectMonorepo` from `detect-monorepo` on the functions source directory. If a workspace root is found (pnpm-workspace.yaml, a parent `package.json` with a `workspaces` field, or `rush.json`), isolation runs automatically. Otherwise the deploy proceeds exactly as in upstream firebase-tools.
 
+`detect-monorepo` walks up from the functions source with a default depth cap. If your functions source is nested deeper than that default and the workspace root isn't being found, set `FIREBASE_TOOLS_ISOLATE_MONOREPO_MAX_DEPTH` to a positive integer (or `Infinity`) to raise the cap:
+
+```bash
+FIREBASE_TOOLS_ISOLATE_MONOREPO_MAX_DEPTH=20 npx firebase deploy
+```
+
 ```json
 {
   "functions": {

--- a/src/deploy/functions/prepareFunctionsUpload.ts
+++ b/src/deploy/functions/prepareFunctionsUpload.ts
@@ -191,9 +191,16 @@ export async function prepareFunctionsUpload(
  * Check whether the given absolute source directory sits inside a monorepo
  * workspace (pnpm, npm/yarn/bun workspaces, or Rush). Used as a cheap gate
  * before invoking isolate-package.
+ *
+ * Uses detect-monorepo's default upward walk depth. Set
+ * FIREBASE_TOOLS_ISOLATE_MONOREPO_MAX_DEPTH to a positive integer (or
+ * Infinity) to raise the cap when the functions source is nested deeper than
+ * the default.
  */
 export function isMonorepoSource(absoluteSourceDir: string): boolean {
-  return detectMonorepo(absoluteSourceDir) !== null;
+  const override = process.env.FIREBASE_TOOLS_ISOLATE_MONOREPO_MAX_DEPTH;
+  const options = override ? { maxDepth: Number(override) } : undefined;
+  return detectMonorepo(absoluteSourceDir, options) !== null;
 }
 
 /**


### PR DESCRIPTION
> [!IMPORTANT]
> This change depends on this PR [0x80/detect-monorepo#2](https://github.com/0x80/detect-monorepo/pull/2)

## Summary

Exposes `detect-monorepo`'s new `maxDepth` option through a `FIREBASE_TOOLS_ISOLATE_MONOREPO_MAX_DEPTH` environment variable so functions sources nested deeper than the library's default 4-level walk can still be recognised as sitting inside a monorepo workspace.

## Motivation

When upgrading to `firebase-tools-with-isolate@15.14.0` we discovered that a few of our cloud functions were not building properly. Turns out this was because they were nested 5 levels deep while `detect-monorepo` only looked 4 levels deep. Raising the cap — or passing `{ maxDepth: Infinity }` to walk all the way to the filesystem root — lets these cases resolve to the correct workspace root.

## Changes

- `src/deploy/functions/prepareFunctionsUpload.ts` — `isMonorepoSource` reads `FIREBASE_TOOLS_ISOLATE_MONOREPO_MAX_DEPTH`, coerces via `Number(...)`, and forwards it to `detectMonorepo` as `{ maxDepth }`. When the env var is unset, behaviour is unchanged (library default).
- `scripts/sync/apply-isolate-changes.mjs` — injected template updated so re-running the sync produces the same patched function.
- `package.json` — bumps `detect-monorepo` from `^1.1.0` to `^1.2.0` (the release containing the new `options` parameter, see [0x80/detect-monorepo#2](https://github.com/0x80/detect-monorepo/pull/2)).
- `README.md` / `scripts/sync/fork-readme.md` — documents the env var under "Configuration".

## Usage

```bash
# walks up to 20 levels instead of the default 4
FIREBASE_TOOLS_ISOLATE_MONOREPO_MAX_DEPTH=20 npx firebase deploy

# walks all the way to the filesystem root
FIREBASE_TOOLS_ISOLATE_MONOREPO_MAX_DEPTH=Infinity npx firebase deploy
```

Invalid values (`0`, negatives, non-integers, non-numeric strings) surface a `TypeError` from `detect-monorepo` rather than silently falling back to the default, so typos fail loudly.

## Backwards compatibility

Non-breaking. The env var is opt-in; unset behaviour is identical to before. Standalone (non-monorepo) projects are unaffected.

## Dependency

Requires `detect-monorepo@^1.2.0`, currently pending release via [0x80/detect-monorepo#2](https://github.com/0x80/detect-monorepo/pull/2). This PR should not be merged until that release is published.

## Test plan

- [ ] `pnpm install` picks up `detect-monorepo@1.2.0` cleanly.
- [ ] `pnpm exec tsc --noEmit` passes (currently errors against 1.1.0 types, as expected).
- [ ] Manual: deploy a functions source nested >4 levels deep without the env var — isolation should *not* run (confirms default).
- [ ] Manual: same source with `FIREBASE_TOOLS_ISOLATE_MONOREPO_MAX_DEPTH=Infinity` — isolation runs (confirms override path).
- [ ] Manual: `FIREBASE_TOOLS_ISOLATE_MONOREPO_MAX_DEPTH=abc firebase deploy` surfaces a clear `TypeError` (confirms loud failure).