### PR TITLE
Trigger publish via workflow_dispatch instead of workflow_call

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -119,4 +119,4 @@ jobs:
         if: steps.check.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run publish.yml --ref main -f dist_tag=latest -f dry_run=false
+        run: gh workflow run publish.yml --ref main -f dist_tag=latest

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -25,7 +25,7 @@ on:
 
 permissions:
   contents: write
-  id-token: write
+  actions: write
 
 concurrency:
   group: sync-upstream
@@ -35,8 +35,6 @@ jobs:
   sync:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    outputs:
-      synced: ${{ steps.result.outputs.synced }}
 
     steps:
       - name: Checkout fork
@@ -113,17 +111,12 @@ jobs:
         if: steps.check.outputs.skip != 'true'
         run: git push origin main
 
-      - name: Set sync result
-        id: result
+      # Dispatched as a separate workflow_dispatch (not workflow_call) so the
+      # OIDC token claims match the npm trusted publisher entry for publish.yml.
+      # Reusable workflow invocations produce a different workflow_ref claim
+      # and are rejected by npm trusted publishing.
+      - name: Trigger publish workflow
         if: steps.check.outputs.skip != 'true'
-        run: echo "synced=true" >> "$GITHUB_OUTPUT"
-
-  publish:
-    needs: sync
-    if: needs.sync.outputs.synced == 'true'
-    uses: ./.github/workflows/publish.yml
-    with:
-      dist_tag: latest
-    permissions:
-      contents: write
-      id-token: write
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run publish.yml --ref main -f dist_tag=latest -f dry_run=false


### PR DESCRIPTION
The scheduled sync-upstream run on 2026-05-07 successfully synced upstream and pushed to main, but the chained publish job failed at the npm publish step with `404 Not Found - PUT https://registry.npmjs.org/firebase-tools-with-isolate`. Provenance signing succeeded, which rules out auth-token issues — every prior successful publish was triggered by `workflow_dispatch` directly on publish.yml, while this was the first time publish ran via `workflow_call` from sync-upstream.

When publish.yml is invoked as a reusable workflow, the OIDC token's `workflow_ref` claim points to the caller (sync-upstream.yml) rather than publish.yml, and the `event_name` claim becomes `schedule`. The npm trusted publisher entry expects the claims produced by a direct `workflow_dispatch` on publish.yml, so it rejects the request with 404.

Replace the `uses: ./.github/workflows/publish.yml` reusable invocation with a `gh workflow run publish.yml` step that dispatches publish as a top-level workflow_dispatch. The OIDC claims then match the trusted publisher entry. `workflow_dispatch` is one of the documented exceptions to the rule that GITHUB_TOKEN-triggered events don't fire new workflow runs, so no PAT is needed — only `actions: write` permission.

Publish failures are no longer surfaced through the sync run's status (consistent with the direction taken in 701dbba2f); they remain visible in the Actions UI.

Scope: infra
Visibility: internal