### PR TITLE
Update detect-monorepo to 1.2.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -34,7 +34,7 @@
         "cross-spawn": "^7.0.5",
         "csv-parse": "^5.0.4",
         "deep-equal-in-any-order": "^2.0.6",
-        "detect-monorepo": "^1.1.0",
+        "detect-monorepo": "^1.2.0",
         "exegesis": "^4.2.0",
         "exegesis-express": "^4.0.0",
         "express": "^4.16.4",
@@ -11724,9 +11724,9 @@
       }
     },
     "node_modules/detect-monorepo": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/detect-monorepo/-/detect-monorepo-1.1.0.tgz",
-      "integrity": "sha512-u8rfcnXiGLNE6kDJ6agixJucItp6UF1fa2KciwHYp2QM0sSlbKHKsd8n9MOmy1R90mvb3ePYHjEAUE/7X9AcAQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/detect-monorepo/-/detect-monorepo-1.2.0.tgz",
+      "integrity": "sha512-w+yWvGFWloYUkGCrONGAuCILhDo3Hb1rrgk4IbB3oA6+eqGJTTflBnnOxwh+0splahWEqAa1gXWtm1vpdhBIog==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
@@ -35576,9 +35576,9 @@
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
     },
     "detect-monorepo": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/detect-monorepo/-/detect-monorepo-1.1.0.tgz",
-      "integrity": "sha512-u8rfcnXiGLNE6kDJ6agixJucItp6UF1fa2KciwHYp2QM0sSlbKHKsd8n9MOmy1R90mvb3ePYHjEAUE/7X9AcAQ=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/detect-monorepo/-/detect-monorepo-1.2.0.tgz",
+      "integrity": "sha512-w+yWvGFWloYUkGCrONGAuCILhDo3Hb1rrgk4IbB3oA6+eqGJTTflBnnOxwh+0splahWEqAa1gXWtm1vpdhBIog=="
     },
     "devalue": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "cross-spawn": "^7.0.5",
     "csv-parse": "^5.0.4",
     "deep-equal-in-any-order": "^2.0.6",
-    "detect-monorepo": "^1.1.0",
+    "detect-monorepo": "^1.2.0",
     "exegesis": "^4.2.0",
     "exegesis-express": "^4.0.0",
     "express": "^4.16.4",


### PR DESCRIPTION
Bumps `detect-monorepo` from `^1.1.0` to `^1.2.0`. The 1.2.0 release replaces the previous 4-level depth cap with a VCS-root boundary (`.git`/`.hg`/`.svn` or filesystem root), so deeply-nested functions sources are detected without needing a configurable depth knob. This obsoletes the env-var approach in #51.

Scope: packages (detect-monorepo)
Visibility: internal